### PR TITLE
Add bash setup script 

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash 
+
+conda create -n xnat_downloader_env python=2.7
+source activate xnat_downloader_env
+conda install -c conda-forge dcm2niix
+python setup.py
+


### PR DESCRIPTION
I was able to successfully run the Docker container on macOS but not Ubuntu, so I tried running `xnat_downloader` using my local installation within a conda python 2.7 environment. It turned out that I didn't have `dcm2niix` installed, so I had to install that as well. Other users may also miss that locally installing and setting up `xnat_downloader` doesn't also install `dcm2niix`, so this PR adds a bash setup script that creates a conda 2.7 env, installs dcm2niix (which also installs `pigz` that's missing from the Docker installation), and runs the existing `setup.py` script.