### PR TITLE
fix: handle renaming of sessions on xnat

### DIFF
--- a/xnat_downloader/cli/run.py
+++ b/xnat_downloader/cli/run.py
@@ -568,16 +568,17 @@ def main():
         else:
             sub_class.get_sessions(session_labels)
         # for every session
-        for session in sub_class.ses_dict.keys():
-            sub_class.get_scans(session, scan_labels)
-            # for each available scan
-            for scan in sub_class.scan_dict.keys():
-                # download the scan
-                if scan_repl_dict:
-                    sub_class.download_scan_unformatted(scan, dest, scan_repl_dict, bids_num_len,
-                                                        sub_repl_dict, sub_label_prefix)
-                else:
-                    sub_class.download_scan(scan, dest, sub_label_prefix)
+        if sub_class.ses:
+            for session in sub_class.ses_dict.keys():
+                sub_class.get_scans(session, scan_labels)
+                # for each available scan
+                for scan in sub_class.scan_dict.keys():
+                    # download the scan
+                    if scan_repl_dict:
+                        sub_class.download_scan_unformatted(scan, dest, scan_repl_dict, bids_num_len,
+                                                            sub_repl_dict, sub_label_prefix)
+                    else:
+                        sub_class.download_scan(scan, dest, sub_label_prefix)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I believe sessions were renamed on xnat for a particular subject and the xnat api still keeps those ghost sessions (only visible via the api), hopefully this fix works around that.

**Error Message**
```
ERROR: No sessions were found
Traceback (most recent call last):
  File "/usr/local/miniconda/bin/xnat_downloader", line 11, in <module>
    load_entry_point('xnat-downloader==0.1', 'console_scripts', 'xnat_downloader')()
  File "/usr/local/miniconda/lib/python2.7/site-packages/xnat_downloader-0.1-py2.7.egg/xnat_downloader/cli/run.py", line 565, in main
    for session in sub_class.ses_dict.keys():
AttributeError: 'NoneType' object has no attribute 'keys'
```