### PR TITLE
upgrade dcm2niix in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,16 +13,20 @@ RUN apt-get update -qq && apt-get install -yq --no-install-recommends  \
     ca-certificates \
     curl \
     git \
-    unzip
+    unzip \
+    pigz
 
-RUN apt-get update -qq && apt-get install -yq --no-install-recommends  \
-    dcm2niix
+RUN mkdir -p /opt/dcm2niix && \
+    cd /opt/dcm2niix && \
+    curl -sSLO https://github.com/rordenlab/dcm2niix/releases/download/v1.0.20181125/dcm2niix_25-Nov-2018_lnx.zip && \
+    unzip dcm2niix_25-Nov-2018_lnx.zip && \
+    rm dcm2niix_25-Nov-2018_lnx.zip
 
 RUN curl -sSLO https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh && \
     bash Miniconda2-latest-Linux-x86_64.sh -b -p /usr/local/miniconda && \
     rm Miniconda2-latest-Linux-x86_64.sh
 
-ENV PATH=/usr/local/miniconda/bin:$PATH \
+ENV PATH=/opt/dcm2niix:/usr/local/miniconda/bin:$PATH \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
 


### PR DESCRIPTION
fixes #20 
The [most recent release](https://github.com/rordenlab/dcm2niix/releases/tag/v1.0.20181125) handles GE NIfTI's better. Importantly, phase-encoding direction can now be inferred from the software.